### PR TITLE
Add jsdelivr CDN purge action

### DIFF
--- a/.github/workflows/purge_cdn.yml
+++ b/.github/workflows/purge_cdn.yml
@@ -15,17 +15,9 @@ jobs:
       - name: Collect changed files
         run: |
           BASE="https://purge.jsdelivr.net/gh/OhMyGuus/BetterCrewLink-Hats@master"
-          BEFORE="${{ github.event.before }}"
 
-          if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
-            # Initial push — purge everything
-            find NONE -name '*.png' > changed.txt
-            echo "hats.json"           >> changed.txt
-            echo "hats_formatted.json" >> changed.txt
-          else
-            git diff --name-only "$BEFORE" HEAD \
-              -- 'NONE/*.png' 'hats.json' 'hats_formatted.json' > changed.txt
-          fi
+          git diff --name-only "${{ github.event.before }}" HEAD \
+            -- 'NONE/*.png' 'hats.json' 'hats_formatted.json' > changed.txt
 
           sed "s|^|$BASE/|" changed.txt > urls.txt
           echo "$(wc -l < urls.txt | tr -d ' ') URLs queued for purge"

--- a/.github/workflows/purge_cdn.yml
+++ b/.github/workflows/purge_cdn.yml
@@ -1,0 +1,42 @@
+name: Purge jsdelivr CDN cache
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect changed files
+        run: |
+          BASE="https://purge.jsdelivr.net/gh/OhMyGuus/BetterCrewLink-Hats@master"
+          BEFORE="${{ github.event.before }}"
+
+          if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+            # Initial push — purge everything
+            find NONE -name '*.png' > changed.txt
+            echo "hats.json"           >> changed.txt
+            echo "hats_formatted.json" >> changed.txt
+          else
+            git diff --name-only "$BEFORE" HEAD \
+              -- 'NONE/*.png' 'hats.json' 'hats_formatted.json' > changed.txt
+          fi
+
+          sed "s|^|$BASE/|" changed.txt > urls.txt
+          echo "$(wc -l < urls.txt | tr -d ' ') URLs queued for purge"
+          cat urls.txt
+
+      - name: Purge CDN (16 parallel)
+        run: |
+          if [ ! -s urls.txt ]; then
+            echo "Nothing to purge."
+            exit 0
+          fi
+          xargs -a urls.txt -P 16 -I{} \
+            curl -fsS -o /dev/null -w "%{http_code}  {}\n" "{}" \
+            || true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/purge_cdn.yml`
- Triggers on every push/merge to `master`
- Diffs the pushed commits to find only changed `NONE/*.png`, `hats.json`, and `hats_formatted.json` files
- Fires 16 parallel purge requests to `purge.jsdelivr.net` so the CDN serves fresh assets immediately after a merge

## Test plan

- [ ] Merge a small change to `master` and confirm the action runs and logs purge status codes